### PR TITLE
add autohintlib to BuildAll target dependencies

### DIFF
--- a/FDK/Tools/Programs/autohint/build/osx/xcode4/autohintexe.xcodeproj/project.pbxproj
+++ b/FDK/Tools/Programs/autohint/build/osx/xcode4/autohintexe.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				FF99806E1B3D5E000020B466 /* PBXTargetDependency */,
 				BDD0854D14E47AD500F0FC0D /* PBXTargetDependency */,
 			);
 			name = BuildAll;
@@ -39,6 +40,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8DD76FA90486AB0100D96B5E;
 			remoteInfo = autohintexe;
+		};
+		FF99806D1B3D5E000020B466 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BD5BF4440D9AD3C80015F645 /* autohintlib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D2AAC045055464E500DB518D;
+			remoteInfo = autohintlib;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -227,6 +235,11 @@
 			isa = PBXTargetDependency;
 			target = 8DD76FA90486AB0100D96B5E /* autohintexe */;
 			targetProxy = BDD0854C14E47AD500F0FC0D /* PBXContainerItemProxy */;
+		};
+		FF99806E1B3D5E000020B466 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = autohintlib;
+			targetProxy = FF99806D1B3D5E000020B466 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
@codeman38 thank you for your patch https://github.com/adobe-type-tools/afdko/pull/59.
However, I still can't get "autohint/build/osx/xcode4/BuildAll.sh" script to compile autohintexe from the command line.
To fix that, we also need to add "autohintlib" to the target dependencies of autohintexe's "BuildAll" scheme.
After I merge your patch with this one, I can successfully run the main "FDK/Tools/Programs/BuildAll.sh" shell script that compiles all osx executables, including autohintexe.
Cheers,

Cosimo
